### PR TITLE
Ekskluderer toppopgaveundersøkelse 03404 på utvalgte urler

### DIFF
--- a/configs/prod/ta-config.json
+++ b/configs/prod/ta-config.json
@@ -193,52 +193,52 @@
       },
       {
         "url": "https://www.nav.no/okonomisk-sosialhjelp",
-        "match": "exact",
+        "match": "startsWith",
         "exclude": true
       },
       {
         "url": "https://www.nav.no/alderspensjon",
-        "match": "exact",
+        "match": "startsWith",
         "exclude": true
       },
       {
         "url": "https://www.nav.no/dagpenger",
-        "match": "exact",
+        "match": "startsWith",
         "exclude": true
       },
       {
         "url": "https://www.nav.no/aap",
-        "match": "exact",
+        "match": "startsWith",
         "exclude": true
       },
       {
         "url": "https://www.nav.no/sykepenger",
-        "match": "exact",
+        "match": "startsWith",
         "exclude": true
       },
       {
         "url": "https://www.nav.no/midlertidig-botilbud",
-        "match": "exact",
+        "match": "startsWith",
         "exclude": true
       },
       {
         "url": "https://www.nav.no/rullestol-scooter/nn",
-        "match": "exact",
+        "match": "startsWith",
         "exclude": true
       },
       {
         "url": "https://www.nav.no/barnetilsyn-enslig",
-        "match": "exact",
+        "match": "startsWith",
         "exclude": true
       },
       {
         "url": "https://www.nav.no/tilleggsstonader",
-        "match": "exact",
+        "match": "startsWith",
         "exclude": true
       },
       {
         "url": "https://www.nav.no/rimelige-hjelpemidler",
-        "match": "exact",
+        "match": "startsWith",
         "exclude": true
       }
     ]

--- a/configs/prod/ta-config.json
+++ b/configs/prod/ta-config.json
@@ -190,7 +190,67 @@
         "url": "https://www.nav.no/",
         "match": "exact",
         "exclude": true
+      },
+      {
+        "url": "https://www.nav.no/okonomisk-sosialhjelp",
+        "match": "exact",
+        "exclude": true
+      },
+      {
+        "url": "https://www.nav.no/alderspensjon",
+        "match": "exact",
+        "exclude": true
+      },
+      {
+        "url": "https://www.nav.no/dagpenger",
+        "match": "exact",
+        "exclude": true
+      },
+      {
+        "url": "https://www.nav.no/aap",
+        "match": "exact",
+        "exclude": true
+      },
+      {
+        "url": "https://www.nav.no/sykepenger",
+        "match": "exact",
+        "exclude": true
+      },
+      {
+        "url": "https://www.nav.no/midlertidig-botilbud",
+        "match": "exact",
+        "exclude": true
+      },
+      {
+        "url": "https://www.nav.no/rullestol-scooter/nn",
+        "match": "exact",
+        "exclude": true
+      },
+      {
+        "url": "https://www.nav.no/barnetilsyn-enslig",
+        "match": "exact",
+        "exclude": true
+      },
+      {
+        "url": "https://www.nav.no/tilleggsstonader",
+        "match": "exact",
+        "exclude": true
+      },
+      {
+        "url": "https://www.nav.no/rimelige-hjelpemidler",
+        "match": "exact",
+        "exclude": true
       }
     ]
   }
 ]
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Begrenser toppoppgaveundersøkelse som ikke skal vises på disse url'ene:
https://www.nav.no/okonomisk-sosialhjelp
https://www.nav.no/alderspensjon
https://www.nav.no/dagpenger
https://www.nav.no/aap
https://www.nav.no/sykepenger
https://www.nav.no/midlertidig-botilbud
https://www.nav.no/rullestol-scooter/nn
https://www.nav.no/barnetilsyn-enslig
https://www.nav.no/tilleggsstonader
https://www.nav.no/rimelige-hjelpemidler