### PR TITLE
Omrokkerer undersøkelsen minside oppdage oppgaver

### DIFF
--- a/configs/prod/ta-config.json
+++ b/configs/prod/ta-config.json
@@ -231,5 +231,13 @@
         "match": "startsWith"
       }
     ]
+  },{
+    "id": "03426",
+    "urls": [
+      {
+        "url": "https://www.nav.no/pensjon/selvbetjening/dinpensjon",
+        "match": "exact"
+      }
+    ]
   }
 ]

--- a/configs/prod/ta-config.json
+++ b/configs/prod/ta-config.json
@@ -91,15 +91,6 @@
     ]
   },
   {
-    "id": "03424",
-    "urls": [
-      {
-        "url": "https://www.nav.no/minside",
-        "match": "exact"
-      }
-    ]
-  },
-  {
     "id": "03407",
     "urls": [
       {
@@ -236,6 +227,15 @@
     "urls": [
       {
         "url": "https://www.nav.no/pensjon/selvbetjening/dinpensjon",
+        "match": "exact"
+      }
+    ]
+  },
+  {
+    "id": "03424",
+    "urls": [
+      {
+        "url": "https://www.nav.no/minside",
         "match": "exact"
       }
     ]


### PR DESCRIPTION
Undersøkelser ser ut til å aktiveres i rekkefølgen de ligger i ta-config.json. Derfor omrokkerer jeg rekkefølgen på undersøkelsen på Min side, for å se om andre undersøkelser blir synlige nå.